### PR TITLE
home: use git-branchless from upstream flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -317,6 +317,24 @@
         "type": "github"
       }
     },
+    "git-branchless": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_5"
+      },
+      "locked": {
+        "lastModified": 1717272431,
+        "narHash": "sha256-ts9LE6993SOLyG1tqq2aT1/z1vRq8mF101p2c10/aCk=",
+        "owner": "arxanas",
+        "repo": "git-branchless",
+        "rev": "1f6317d9b60285d2d566e328a8ba6c263adc324d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "arxanas",
+        "repo": "git-branchless",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -532,7 +550,7 @@
       "inputs": {
         "flake-compat": "flake-compat_3",
         "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1716028628,
@@ -688,6 +706,20 @@
     },
     "nixpkgs_5": {
       "locked": {
+        "lastModified": 1708373374,
+        "narHash": "sha256-yEyDvDj/YQc4GOZa/cXx6YUzexD8uv1rUvD6SJVr6UI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "93e1c2d08467d1117ebac45689469613a9fe8453",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_6": {
+      "locked": {
         "lastModified": 1714782413,
         "narHash": "sha256-tbg0MEuKaPcUrnmGCu4xiY5F+7LW2+ECPKVAJd2HLwM=",
         "owner": "NixOS",
@@ -702,7 +734,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1717196966,
         "narHash": "sha256-yZKhxVIKd2lsbOqYd5iDoUIwsRZFqE87smE2Vzf6Ck0=",
@@ -718,7 +750,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_8": {
       "locked": {
         "lastModified": 1705856552,
         "narHash": "sha256-JXfnuEf5Yd6bhMs/uvM67/joxYKoysyE3M2k6T3eWbg=",
@@ -733,7 +765,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_8": {
+    "nixpkgs_9": {
       "locked": {
         "lastModified": 1708475490,
         "narHash": "sha256-g1v0TsWBQPX97ziznfJdWhgMyMGtoBFs102xSYO4syU=",
@@ -809,12 +841,13 @@
         "devenv": "devenv",
         "disko": "disko",
         "flake-parts": "flake-parts",
+        "git-branchless": "git-branchless",
         "home-manager": "home-manager_2",
         "impermanence": "impermanence",
         "nix-index-db": "nix-index-db",
         "nixos-generators": "nixos-generators",
         "nixos-wsl": "nixos-wsl",
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_7",
         "nixpkgs-stable": "nixpkgs-stable_2",
         "simple-nixos-mailserver": "simple-nixos-mailserver",
         "treefmt-nix": "treefmt-nix"
@@ -824,7 +857,7 @@
       "inputs": {
         "blobs": "blobs",
         "flake-compat": "flake-compat_4",
-        "nixpkgs": "nixpkgs_7",
+        "nixpkgs": "nixpkgs_8",
         "utils": "utils"
       },
       "locked": {
@@ -904,7 +937,7 @@
     },
     "treefmt-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_8"
+        "nixpkgs": "nixpkgs_9"
       },
       "locked": {
         "lastModified": 1715940852,

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
     disko.url = "github:nix-community/disko/v1.3.0";
     nixos-wsl.url = "github:nix-community/nixos-wsl?ref=main";
     comin.url = "github:nlewo/comin";
+    git-branchless.url = "github:arxanas/git-branchless";
   };
 
   outputs = {flake-parts, ...} @ inputs:

--- a/modules/home/user/git.nix
+++ b/modules/home/user/git.nix
@@ -1,4 +1,4 @@
-{pkgs, ...}: {
+{pkgs, flakeInputs, ...}: {
   programs.git = {
     enable = true;
     delta.enable = true;
@@ -18,6 +18,6 @@
   };
 
   home.packages = [
-    pkgs.git-branchless
+    flakeInputs.git-branchless.packages.x86_64-linux.git-branchless
   ];
 }


### PR DESCRIPTION
home: use git-branchless from upstream flake

this comes with version 0.9
