### PR TITLE
rust-template: remove fenix toolchain from packages

### DIFF
--- a/modules/templates/rust/flake.nix
+++ b/modules/templates/rust/flake.nix
@@ -39,9 +39,7 @@
           # https://github.com/cachix/devenv/issues/528
           containers = lib.mkForce {};
           languages.rust.enable = true;
-          packages = [
-            pkgs.fenix.stable.toolchain
-          ];
+          packages = [];
         };
       };
     });


### PR DESCRIPTION
rust-template: remove fenix toolchain from packages
