### PR TITLE
paperless: temporarily disable

### DIFF
--- a/modules/home/user/git.nix
+++ b/modules/home/user/git.nix
@@ -24,5 +24,6 @@
   home.packages = [
     flakeInputs.git-branchless.packages.x86_64-linux.git-branchless
     pkgs.jujutsu
+    pkgs.meld
   ];
 }

--- a/modules/nixos/muehml/paperless.nix
+++ b/modules/nixos/muehml/paperless.nix
@@ -8,7 +8,8 @@ in {
   impermanence.directories = [config.services.paperless.dataDir];
 
   services.paperless = {
-    enable = true;
+    ## Temporarily disabled due to build failure
+    # enable = true;
     settings = {
       PAPERLESS_DBHOST = "/run/postgresql";
       PAPERLESS_OCR_LANGUAGE = "deu+eng+swe";


### PR DESCRIPTION
paperless: temporarily disable

Repeated build failures, blocks update for too long.
