### PR TITLE
Switch to caddy as reverse proxy

### DIFF
--- a/nix/nixos/muehml/atticd.nix
+++ b/nix/nixos/muehml/atticd.nix
@@ -55,18 +55,13 @@ in
     ];
   };
 
-  services.nginx.virtualHosts."${subdomain}.${config.networking.fqdn}" = {
-    enableACME = true;
-    forceSSL = true;
-    locations."/" = {
-      proxyPass = "http://${toString config.services.atticd.settings.listen}";
-      extraConfig = "client_max_body_size 1G;";
-    };
-  };
+  services.caddy.virtualHosts."${subdomain}.${config.networking.fqdn}".extraConfig = ''
+    reverse_proxy http://${toString config.services.atticd.settings.listen}
+  '';
+  # extraConfig = "client_max_body_size 1G;";
 
   sops.secrets = {
     attic-credentials = { };
-
     storage-box-attic = { };
   };
 }

--- a/nix/nixos/muehml/default.nix
+++ b/nix/nixos/muehml/default.nix
@@ -12,9 +12,9 @@
     ./impermanence.nix
     # ./grafana.nix
     ./mail-server.nix
-    ./navidrome.nix
+    # ./navidrome.nix
     ./nextcloud-server.nix
-    ./paperless.nix
+    # ./paperless.nix
     ./vaultwarden.nix
   ];
 
@@ -134,25 +134,21 @@
   ];
 
   security.acme = {
-    defaults.email = "lars@muehml.eu";
+    defaults = {
+      email = "lars@muehml.eu";
+      dnsProvider = "hetzner";
+      credentialFiles."HETZNER_API_TOKEN_FILE" = config.sops.secrets.hetzner-dns-api-token.path;
+    };
     acceptTerms = true;
   };
 
-  services.nginx = {
-    recommendedGzipSettings = true;
-    recommendedOptimisation = true;
-    recommendedTlsSettings = true;
-    recommendedProxySettings = true;
-    virtualHosts."forward.muehml.eu" = {
-      forceSSL = true;
-      enableACME = true;
-      locations."/".proxyPass = "http://localhost:54321";
-    };
+  sops.secrets.hetzner-dns-api-token.group = "acme";
+
+  services.caddy = {
+    enable = true;
+    email = config.security.acme.defaults.email;
+    openFirewall = true;
   };
-  networking.firewall.allowedTCPPorts = [
-    80
-    443
-  ];
 
   services.postgresql = {
     package = pkgs.postgresql_16;

--- a/nix/nixos/muehml/mail-server.nix
+++ b/nix/nixos/muehml/mail-server.nix
@@ -18,5 +18,5 @@
 
   sops.secrets.emailHashedPassword = { };
 
-  services.nginx.virtualHosts.${config.mailserver.fqdn}.enableACME = true;
+  security.acme.certs.${config.mailserver.fqdn} = { };
 }

--- a/nix/nixos/muehml/nextcloud-server.nix
+++ b/nix/nixos/muehml/nextcloud-server.nix
@@ -47,12 +47,19 @@ in
     after = [ "postgresql.service" ];
   };
 
-  services.nginx.virtualHosts = {
-    ${domain} = {
-      enableACME = true;
-      forceSSL = true;
-    };
+  services.nginx = {
+    enable = true;
+    recommendedGzipSettings = true;
+    recommendedOptimisation = true;
+    recommendedTlsSettings = true;
+    recommendedProxySettings = true;
+    defaultHTTPListenPort = 8080;
+    defaultListenAddresses = [ "127.0.0.1" ];
   };
+
+  services.caddy.virtualHosts.${domain}.extraConfig = ''
+    reverse_proxy :8080
+  '';
 
   # For mount.cifs, required unless domain name resolution is not needed.
   environment.systemPackages = [ pkgs.cifs-utils ];

--- a/nix/nixos/muehml/vaultwarden.nix
+++ b/nix/nixos/muehml/vaultwarden.nix
@@ -41,11 +41,7 @@ in
     owner = "vaultwarden";
   };
 
-  services.nginx.virtualHosts."${subdomain}.${config.networking.fqdn}" = {
-    enableACME = true;
-    forceSSL = true;
-    locations."/" = {
-      proxyPass = "http://${toString config.services.vaultwarden.config.ROCKET_ADDRESS}:${toString config.services.vaultwarden.config.ROCKET_PORT}";
-    };
-  };
+  services.caddy.virtualHosts."${subdomain}.${config.networking.fqdn}".extraConfig = ''
+    reverse_proxy http://${toString config.services.vaultwarden.config.ROCKET_ADDRESS}:${toString config.services.vaultwarden.config.ROCKET_PORT}
+  '';
 }

--- a/nix/secrets/muehml.eu.yaml
+++ b/nix/secrets/muehml.eu.yaml
@@ -9,10 +9,10 @@ attic-credentials: ENC[AES256_GCM,data:dvXiyODEP8u0XgbtW5QhkCr0RHi7DmPVKCEAZTL1b
 netrc-larstop2: ENC[AES256_GCM,data:xxzENaR+iOvO7PuxvDbNo6mSQxq3quskfbYnf5R0Vg/RntnMzArbCq2IhX2dh6Kt80BRg+ncybmvdKRWkbjgTskJvn2oYHX+ATslLsoelUN1ojolDuHCRKgQ/frC/QCYnzX9oN3GxTzSohDaxsS01zhJuZb7M28vSkxXXNphT+EeItBliXIJevJYxvfAcS2MfgmuK7KEEUVDReVFtQ3eI8Eh0qcplovfvfA7fufXx8vUFAoHahbuH4NKuw+tqeRt2sQyxM4AjcQhadBvdFeX9A63McW+uQT4+fXIwZn1r4r9LcVKLR4LduNyeQj2jXYUUX+G8o2S,iv:8CHP80a9unRG8KtpXz72mvw/HcOG3SNTI+NLo0cZsNs=,tag:ECXF+aMl9ja9nXIzaaoC0A==,type:str]
 netrc-muehml: ENC[AES256_GCM,data:O8LVh3UJFDGC1D5E9mN0OJUzQdFSV08uJSQcrg7SJrL99XGp+w4IiM9cjZOx4xQ/NruS1U2vL1qc0JydnVfoGPYlEHVPJztuvXgaeIToMGpONpMhqJfiEIpTimVhFE6/NmjwtSVAvlKyCdAnePo4/EYuVrpiSA4M2lpvjdYBCux4Z+M2/2EOS6BAWTlStSsT0GihhhQcjSAax1o579BVrncxepbK1ASL9whhPnaH1xiLgeFrB6JqUlxtqgSekPcs5A5WpeUozNCviajbCiR6Sq74VRNJow/pEPKHrr0QiTsk4jrC,iv:yGxNmmZ53RvcsxLed9dDqTiE1dzTP11glinPxhfCN68=,tag:fbfH/XyWSVBEtq4/ewEMiw==,type:str]
 grafana-initial-password: ENC[AES256_GCM,data:qU5WYNNdpTpk70cRZyGafEHhxN4=,iv:wYKtA4o1LPuGmdtF2a2yq7YG+3T668bVlmTBbVLc3e0=,tag:pK2MTpeF16C+59UvLkFd8w==,type:str]
+hetzner-dns-api-token: ENC[AES256_GCM,data:j+qrLXnNwRbVAhD2D7BgyhIGm8gaEArhhocMWryY2HgDr1HmmdEwYl5syJMPESMe6icvpwuuKX9UNb0L+t2l7A==,iv:h0X2z7rvrTomJKtjqPXScBK8NbAjhYPWc2uFEhL6rXM=,tag:jxazdxOg3M8uvAHhZefgyg==,type:str]
 sops:
     age:
-        - recipient: age1j7v73aqlq3ztnhfuwlu6gjant5yqk58sleq9ayc9z0rj2ng2ls8qp8tket
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPdTEwbC84RUJTRDQwbGZQ
             OXJnTzdCSmdsclNkMWVWc2cvYW9sdlIvaW1ZCkZDdW9lZVBCTjNsbWxRTnRPdjRG
@@ -20,8 +20,8 @@ sops:
             UmZEbk96U1AxUWxFMnNXYUIySTdOUDQKT3E30ot29Ri85sxBG9iMn6y51XNA0dXQ
             81827t7SOkvV2zcFEltqlBSocPNybx80YhNAUySimtsmcyGQaBKjKg==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age18xluezp2cypkscd80w4hv0vzgeyqu2uvqdxn3ta4uyphvvad8dqqrrvmnp
-          enc: |
+          recipient: age1j7v73aqlq3ztnhfuwlu6gjant5yqk58sleq9ayc9z0rj2ng2ls8qp8tket
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLR1hFdDVlWnlYdThkTW80
             ZzZyYkNBcWFDQVB3R3pROXFJS1Y3UU5aZXdzCjU4T3lhL05hQWtwV3diVHlzeU5v
@@ -29,8 +29,8 @@ sops:
             VUxTb1A2SmxEWDZ2Ylp3S2tMOGhMWEEKcXcaC/sAsLBLlwMQBdVYtabIX/Nk2iRq
             2MevSRBql+JxjAdSLrsbZxuLcWE1tqJjD9b7MLXA/s2tvJXqau+gsw==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAgevajch6O5ZQYWubHgaRZPnhrFM937mjUQO4gT+Bnr user@bluefin
-          enc: |
+          recipient: age18xluezp2cypkscd80w4hv0vzgeyqu2uvqdxn3ta4uyphvvad8dqqrrvmnp
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNzaC1lZDI1NTE5IG0yMWdiQSAzb2RZ
             S2dDRDhpbXFEamcxS0IxeWNOYysxM0dxaGhpVThsUnZmdDQwOWw4CmVMTm9nRkYv
@@ -39,7 +39,8 @@ sops:
             HpyqApZIVxDpSLtdYkpfjYFzBtEdjLFWnF62gsKmur138yYOQmKy4SEGeMf+eXl/
             rCwhcQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-05-29T15:54:32Z"
-    mac: ENC[AES256_GCM,data:E1E24gv3LXzIv3/qygpv1be29JkLAYZDavdnZeCWQ8AzwYbfAsTYrnum3qLxBmMriJUKp6jj2Sr5+5yWWzyGfBoLOVBsi/UiDqmFM/PNcwAobchbEKJPZP2+8j88k++dLXfzujerlrlTMeEvdsq2zGKzuaSC1PK4so1vtLQHxH4=,iv:XOAvvkGT0DNKiZXidgdfdVFRW4GUOs5yH+iE6g3RiKc=,tag:A+sA7bquTQxU+j7CPXQhsg==,type:str]
+          recipient: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAgevajch6O5ZQYWubHgaRZPnhrFM937mjUQO4gT+Bnr user@bluefin
+    lastmodified: "2026-06-25T20:11:20Z"
+    mac: ENC[AES256_GCM,data:IUuBXqxJDBOA7UOecYzB4gVnPQoWKoI/StxAM2ehtvQ8iTal3wAeV2E1u1iLNQ8d2M2vRCRz3jpVnPk8p+vhOzwMFPo1xvr4672tPZXW7xz16rBAXQiy7fREdF0DMll1WJsNoIBsbxeqBmalIyxT6ykpIW9yllW543YaWNfTjd0=,iv:Aw7mL4dLdqBcDWSgVFZUpeYi8HQKzYhrTdgd9n6pFLo=,tag:QoTF7K10qF+hxHfdPyS44g==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.10.2
+    version: 3.13.1

--- a/projects/decl-shadow-test/part.nix
+++ b/projects/decl-shadow-test/part.nix
@@ -51,21 +51,14 @@
     { pkgs, ... }:
     {
       networking.firewall.allowedUDPPorts = [ 443 ];
-      services.nginx = {
+      services.caddy = {
         virtualHosts."decl-shadow-test.muehml.eu" = {
-          forceSSL = true;
-          enableACME = true;
-          quic = true;
-          locations."/" = {
-            root = withSystem "x86_64-linux" ({ config, ... }: config.packages.decl-shadow-test-site);
-            index = "index.html";
-            extraConfig = ''
-              if ($arg_cachebust) {
-                add_header Cache-Control "max-age=31536000,immutable";
-              }
-              add_header Alt-Svc "h3=\":443\"";
-            '';
-          };
+          extraConfig = ''
+            root ${withSystem "x86_64-linux" ({ config, ... }: config.packages.decl-shadow-test-site)}
+            @cachebuster query cachebust=*
+            header @cachebuster Cache-Control max-age=31536000,immutable
+            file_server
+          '';
         };
       };
     };


### PR DESCRIPTION
Nextcloud is still using NixOS' default nginx setup, behind Caddy as a reverse proxy.
Gotta use dns challenge for email, as caddy is not integrated into the security.acme module